### PR TITLE
Use numeric binlog index comparison

### DIFF
--- a/tap_mysql/sync_strategies/binlog.py
+++ b/tap_mysql/sync_strategies/binlog.py
@@ -617,10 +617,14 @@ def _run_binlog_sync(
         log_file = reader.log_file
         log_pos = reader.log_pos
 
+        # Extract numeric log file indexes
+        log_file_index = int(log_file.split('.')[-1])
+        end_log_file_index = int(end_log_file.split('.')[-1])
+
         # The iterator across python-mysql-replication's fetchone method should ultimately terminate
         # upon receiving an EOF packet. There seem to be some cases when a MySQL server will not send
         # one causing binlog replication to hang.
-        if (log_file > end_log_file) or (end_log_file == log_file and log_pos >= end_log_pos):
+        if (log_file_index > end_log_file_index) or (end_log_file == log_file and log_pos >= end_log_pos):
             LOGGER.info('BinLog reader (file: %s, pos:%s) has reached or exceeded end position, exiting!',
                         log_file,
                         log_pos)


### PR DESCRIPTION
## Problem

`tap-mysql` compares binlog filenames as strings instead of by their numeric suffix. This causes incorrect behavior when filenames like `mysql-bin-changelog.999586` are compared to `mysql-bin-changelog.1000176`:

```python
'mysql-bin-changelog.999586' > 'mysql-bin-changelog.1000176'  # Incorrect result
```

This leads the tap to incorrectly assume it has reached or passed the end of the binlog stream, causing it to exit early and skip data.

## Proposed changes

Parses and compare the numeric suffix of each binlog filename.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)